### PR TITLE
Remove version from show-plugin btest in prep for Bro 2.7

### DIFF
--- a/tests/Baseline/dag.show-plugin/output
+++ b/tests/Baseline/dag.show-plugin/output
@@ -1,3 +1,3 @@
-Endace::DAG - Packet acquisition via Endace DAG capture cards (dynamic, version 0.2)
+Endace::DAG - Packet acquisition via Endace DAG capture cards (dynamic, version)
     [Packet Source] DAGReader (interface prefix "endace"; supports live input)
 

--- a/tests/dag/show-plugin.bro
+++ b/tests/dag/show-plugin.bro
@@ -1,2 +1,2 @@
-# @TEST-EXEC: bro -NN Endace::DAG >output
+# @TEST-EXEC: bro -NN Endace::DAG |sed -e 's/version.*)/version)/g' >output
 # @TEST-EXEC: btest-diff output


### PR DESCRIPTION
Update show-plugin.bro test to remove the version number from the baseline output.
With Bro 2.7, the version will be built from major.minor.patch, which conflicts with
the current major.minor in the baseline.